### PR TITLE
Adds Throne Room + Tests, Context Stack Resolution Change

### DIFF
--- a/engine/agent.py
+++ b/engine/agent.py
@@ -1,23 +1,23 @@
 
 class Agent(object):
-	def choose(self, decision, state):
-		return decision.moves[0]
+        def choose(self, decision, state):
+            return [0]
 
 class StdinAgent(Agent):
-	def choose(self, decision, state):
-		# Autoplay
-		if len(decision.moves) == 1:
-			return [0]
+        def choose(self, decision, state):
+                # Autoplay
+                if len(decision.moves) == 1:
+                    return [0]
 
-		print(decision.prompt)
-		for idx, move in enumerate(decision.moves):
-			print(f"{idx}: {move}")
-		ans = list(map(lambda x: int(x.strip()), input().split(',')))
+                print(decision.prompt)
+                for idx, move in enumerate(decision.moves):
+                        print(f"{idx}: {move}")
+                ans = list(map(lambda x: int(x.strip()), input().split(',')))
 
-		return ans
+                return ans
 
 
 class BigMoneyAgent(Agent):
-	def choose(self, decision, state):
-		pass
+        def choose(self, decision, state):
+                pass
 

--- a/engine/cards/base.py
+++ b/engine/cards/base.py
@@ -170,6 +170,7 @@ class TrashCardsContext(ctx.ChooseCardsFromHandContext):
         for card in self.cards:
             player_trash_card_from_hand(self.state, self.player, card)
 
+
 class TrashCardsEffect(effect.Effect):
     def __init__(self, num_cards, filter_type, optional):
         self.num_cards = num_cards
@@ -201,6 +202,7 @@ class GainCardFromSupplyContext(ctx.ChoosePileFromSupplyContext):
 
     def resolve(self):
         gain_card_to_discard(self.state, self.player, self.pile)
+
 
 class ChooseCardToGainFromSupplyEffect(effect.Effect):
     def __init__(self, filter_func):
@@ -254,6 +256,7 @@ class ApplyEffectToOpponentsContext(ctx.Context):
     def resolve(self, state):
         pass
 
+
 class OpponentsDiscardDownToEffect(effect.Effect):
 
     def __init__(self, num_cards_downto):
@@ -270,6 +273,7 @@ class OpponentsDiscardDownToEffect(effect.Effect):
         # TODO(benzy): Please fix this stupid hack somehow.
         # We need can't move this to __init__ for ApplyEffectToOpponentsContext.
         state.context_stack[-1].update(None)
+
 
 class OpponentsGainCardEffect(effect.Effect):
     def __init__(self, card_name):
@@ -288,6 +292,40 @@ class OpponentsGainCardEffect(effect.Effect):
         # We need can't move this to __init__ for ApplyEffectToOpponentsContext.
         state.context_stack[-1].update(None)
 
+
+class PlayActionFromHandTwiceContext(ctx.ChooseCardsFromHandContext):
+    def __init__(self, state, player, num_cards, filter_type, optional, prompt):
+        super().__init__(
+            state,
+            player,
+            num_cards,
+            filter_type,
+            optional,
+            prompt,
+        )
+
+    def resolve(self, state):
+        for card in self.cards:
+            play_card_from_hand_twice(self.state, self.player, card)
+
+
+class PlayActionFromHandTwiceEffect(effect.Effect):
+    def __init__(self):
+        self.prompt = 'You may play an action card from your hand twice'
+
+    def run(self, state, player):
+        state.add_context(
+            PlayActionFromHandTwiceContext(
+                state=state,
+                player=player,
+                num_cards=1,
+                filter_type=CardType.ACTION,
+                optional=True,
+                prompt=self.prompt,
+            )
+        )
+
+
 Militia = Card(
     name="Militia",
     types=[CardType.ACTION, CardType.ATTACK],
@@ -295,13 +333,14 @@ Militia = Card(
     coins=2,
     effect_list=[OpponentsDiscardDownToEffect(3)])
 
-# TODO(benzyx): add vp_func attribute or something.
+
 Gardens = Card(
     name="Gardens",
     types=[CardType.VICTORY],
     cost=4,
     vp_fn=lambda all_cards: len(all_cards)
 )
+
 
 Chapel = Card(
     name="Chapel",
@@ -310,12 +349,14 @@ Chapel = Card(
     effect_list=[TrashCardsEffect(4, filter_type=None, optional=True)]
 )
 
+
 Witch = Card(
     name="Witch",
     types=[CardType.ACTION, CardType.ATTACK],
     cost=5,
     add_cards=2,
     effect_list=[OpponentsGainCardEffect("Curse")])
+
 
 Workshop = Card(
     name="Workshop",
@@ -328,19 +369,21 @@ Workshop = Card(
     ]
 )
 
-"""
+
 ThroneRoom = Card(
     name="Throne Room",
     types=[CardType.ACTION],
     cost=4,
-    effect_list=[Throne(2)],
+    effect_list=[PlayActionFromHandTwiceEffect()],
 )
 
+"""
 Remodel = Card(
     name="Remodel",
     types=[CardType.ACTION],
     cost=4,
     effect_list=[TrashAndGainUpToEffect()])
+
 
 Bandit = Card(
     name="Bandit",
@@ -348,5 +391,5 @@ Bandit = Card(
 )
 
 
-
 """
+

--- a/engine/context.py
+++ b/engine/context.py
@@ -87,7 +87,7 @@ class ChooseCardsFromHandContext(Context):
         return self.num_remaining == 0 or self.done
 
     def update(self, card):
-        if card:
+        if card is not None:
             self.num_remaining -= 1
             self.cards.append(card)
         else:
@@ -104,6 +104,8 @@ class ChooseCardsFromHandContext(Context):
         def __init__(self, player, context, num_select, prompt, filter_type=None, optional=True):
             moves = []
 
+            if optional:
+                moves.append(self.AddCardToContext(None, context))
             for card_idx, card in enumerate(player.hand):
                 if filter_type is None or card.is_type(filter_type):
                     moves.append(self.AddCardToContext(card, context))

--- a/engine/game.py
+++ b/engine/game.py
@@ -8,8 +8,8 @@ from enum import Enum
 
 
 class Game(object):
-    def __init__(self, agents):
-        self.state = GameState(len(agents))
+    def __init__(self, agents, players=None):
+        self.state = GameState(len(agents), players=players)
         self.agents = agents
 
     def run(self):
@@ -21,13 +21,12 @@ class Game(object):
             player = decision.player
 
             agent = self.agents[player.idx]
-            
+
             # Print state of the board.
             print(state)
             print(f" ==== Decision to be made by {player} ==== ")
             print(f"Actions: {player.actions} | Buys: {player.buys} | Coins: {player.coins}")
             print("Hand: ", list(map(str, player.hand)))
-
 
             while True:
                 # Get decision from agent.

--- a/engine/state.py
+++ b/engine/state.py
@@ -7,17 +7,27 @@ class Player(object):
     """
     Player State Object.
     """
-    def __init__(self, name, idx):
+    def __init__(self,
+                 name,
+                 idx,
+                 vp=None,
+                 actions=None,
+                 coins=None,
+                 buys=None,
+                 draw_pile=None,
+                 discard_pile=None,
+                 hand=None,
+                 play_area=None):
         self.name = name
         self.idx = idx
-        self.vp = 0
-        self.actions = 0
-        self.coins = 0
-        self.buys = 0
-        self.draw_pile = [Copper for _ in range(7)] + [Estate for _ in range(3)]
-        self.discard_pile = []
-        self.hand = []
-        self.play_area = []
+        self.vp = vp or 0
+        self.actions = actions or 0
+        self.coins = coins or 0
+        self.buys = buys or 0
+        self.draw_pile = draw_pile or [Copper for _ in range(7)] + [Estate for _ in range(3)]
+        self.discard_pile = discard_pile or []
+        self.hand = hand or []
+        self.play_area = play_area or []
         self.phase = TurnPhase.END_PHASE
 
         shuffle(self.draw_pile)
@@ -91,10 +101,10 @@ class GameState(object):
     """
     Keeps track of the game state.
     """
-    def __init__(self, num_players):
+    def __init__(self, num_players, players=None):
         self.trash = []
         self.turn = 0
-        self.players = [Player(f"Player {i+1}", i) for i in range(num_players)]
+        self.players = players or [Player(f"Player {i+1}", i) for i in range(num_players)]
         self.current_player_idx = 0
         self.context_stack = [TurnContext(self)]
 
@@ -122,8 +132,9 @@ class GameState(object):
             "Workshop" : SupplyPile(Workshop, 10),
         }
 
-        for player in self.players:
-            player.draw(5)
+        if players is None:
+            for player in self.players:
+                player.draw(5)
 
         self.players[0].init_turn()
 
@@ -168,8 +179,9 @@ class GameState(object):
         province_pileout = False
         pileout_count = 0
         for _, pile in self.supply_piles.items():
+            print(pile.card.name)
             if pile.card.name == "Province" and pile.qty == 0:
-                province_pilout = True
+                province_pileout = True
             if pile.qty == 0:
                 pileout_count += 1
         return pileout_count >= 3 or province_pileout
@@ -192,16 +204,25 @@ class GameState(object):
         return context.get_decision()
 
     def resolve_contexts(self):
-        while self.current_context().can_resolve:
-            result = self.current_context().resolve(self)
-            self.pop_context()
-            self.current_context().update(result)
+        while self.current_context.can_resolve:
+            current_idx = self.context_len - 1
+            result = self.current_context.resolve(self)
+            self.pop_context(current_idx)
+            """
+            TODO (henry-prior): check w Ben if this was necessary
+            """
+            #self.current_context.update(result)
 
+    @property
+    def context_len(self):
+        return len(self.context_stack)
+
+    @property
     def current_context(self):
         return self.context_stack[-1]
 
     def add_context(self, context):
         self.context_stack.append(context)
 
-    def pop_context(self):
-        self.context_stack.pop()
+    def pop_context(self, idx=-1):
+        self.context_stack.pop(idx)

--- a/engine/state_funcs.py
+++ b/engine/state_funcs.py
@@ -16,20 +16,40 @@ def play_card_from_hand(state, player, card):
     player.play_area.append(card)
     card.play(state, player)
 
+
+def play_card_from_hand_twice(state, player, card, costs_action=False):
+    """
+    Play card from hand twice (Throne Room-like effects). Usually does not
+    decrease actions, so must be explicitly passed if this is the case.
+    """
+    if costs_action:
+        assert(player.actions > 0)
+        player.actions -= 1
+
+    card_idx = player.hand.index(card)
+    player.hand.pop(card_idx)
+    player.play_area.append(card)
+    card.play(state, player)
+    card.play(state, player)
+
+
 def gain_card_to_discard(state, player, pile):
     if pile.qty > 0:
         player.discard_pile.append(pile.card)
         pile.qty -= 1
+
 
 def gain_card_to_hand(state, player, pile):
     if pile.qty > 0:
         player.hand.append(pile.card)
         pile.qty -= 1
 
+
 def gain_card_to_topdeck(state, player, pile):
     if pile.qty > 0:
         player.deck.append(pile.card)
         pile.qty -= 1
+
 
 def buy_card(state, player, card_name):
     """
@@ -49,12 +69,15 @@ def buy_card(state, player, card_name):
 
     gain_card_to_discard(state, player, pile)
 
+
 def player_discard_card_from_hand(state, player, card):
     card_idx = player.hand.index(card)
     player.hand.pop(card_idx)
     player.discard_pile.append(card)
 
+
 def player_trash_card_from_hand(state, player, card):
     card_idx = player.hand.index(card)
     player.hand.pop(card_idx)
     state.trash.append(card)
+

--- a/engine/tests/test_cards.py
+++ b/engine/tests/test_cards.py
@@ -1,0 +1,19 @@
+import pytest
+from ..game import Game
+from ..agent import Agent
+from ..state import Player
+from ..cards.base import *
+from .utils import *
+
+
+class TestCards:
+    def test_throne_room(self):
+        player1 = Player(
+            'Player 1',
+            0,
+            hand=[ThroneRoom for _ in range(3)] + [Village for _ in range(3)],
+        )
+        player2 = Player('Player 2', 1)
+        players = [player1, player2]
+        game = Game([ThroneRoomAgent(), Agent()], players=players)
+        game.run()

--- a/engine/tests/utils.py
+++ b/engine/tests/utils.py
@@ -1,0 +1,28 @@
+from ..agent import Agent
+from ..card import CardType
+
+class ThroneRoomAgent(Agent):
+    """
+    TODO (henry-prior): clean up this try-except mess by creating a cleaner
+        interface around `move` which allows us to check these attributes even
+        if `None`
+    """
+    def choose(self, decision, state):
+        for idx, move in enumerate(decision.moves):
+            print(f"{idx}: {move}")
+            try:
+                if move.card.name == 'Throne Room':
+                    return [idx]
+            except:
+                pass
+
+        for idx, move in enumerate(decision.moves):
+            try:
+                if move.card.is_type(CardType.ACTION):
+                    state.supply_piles['Province'].qty = 0
+                    return [idx]
+            except:
+                pass
+
+        return [0]
+


### PR DESCRIPTION
- Adds Throne Room by using `PlayCardFromHandTwiceContext`
- Adds ability to create custom `Player` object to initialize game from a specific state (for example with a specific hand, deck, discard). Important for testing now, will be more important later on.
- Adds test for Throne Room
- Changes how context stack resolves (need to discuss w/ @benzyx ). Previously if the resolution of a context added further contexts to the stack, the top of the stack context was resolved rather than the context at the index corresponding to the previous top of stack.